### PR TITLE
Updating to ROOT v6

### DIFF
--- a/example-lib/CMakeLists.txt
+++ b/example-lib/CMakeLists.txt
@@ -15,3 +15,11 @@ add_library(analysiscpp-myanalysis SHARED ${sources} ${headers} ${}analysiscpp-M
 target_link_libraries(analysiscpp-myanalysis utilities datamodel albers ${ROOT_LIBRARIES} ${ROOT_COMPONENT_LIBRARIES})
 
 install(TARGETS analysiscpp-myanalysis DESTINATION lib)
+
+# Install the dictionary
+if (${ROOT_VERSION} GREATER 6)
+  install(FILES
+      "${PROJECT_BINARY_DIR}/example-lib/analysiscpp-MyAnalysisDict_rdict.pcm"
+      DESTINATION lib COMPONENT dev)
+endif()
+

--- a/example-lib/MyAnalysis.h
+++ b/example-lib/MyAnalysis.h
@@ -6,12 +6,12 @@
 
 namespace albers {
   class EventStore;
-  class Reader; 
-};
+  class Reader;
+}
 
 class MyAnalysis {
  public:
-  MyAnalysis(); 
+  MyAnalysis();
   void loop(const char* filename);
   void processEvent(albers::EventStore& store, bool verbose,
 		    albers::Reader& reader);

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,6 @@
 export PATH=/afs/cern.ch/sw/lcg/releases/LCG_72a/fastjet/3.1.1/x86_64-slc6-gcc48-opt/bin:/afs/cern.ch/sw/lcg/contrib/CMake/2.8.9/Linux-i386/bin:${PATH}
-source /afs/cern.ch/sw/lcg/contrib/gcc/4.8.1/x86_64-slc6/setup.sh
-source /afs/cern.ch/sw/lcg/app/releases/ROOT/5.34.20/x86_64-slc6-gcc48-opt/root/bin/thisroot.sh
+source /afs/cern.ch/sw/lcg/contrib/gcc/4.9.3/x86_64-slc6/setup.sh
+source /afs/cern.ch/exp/fcc/sw/0.5/LCG_80/ROOT/6.04.06/x86_64-slc6-gcc49-opt/bin/thisroot.sh
 
 export ANALYSISCPP=$PWD/install
 export LD_LIBRARY_PATH=$ANALYSISCPP/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Updated the init.sh script to use GCC / ROOT versions as used currently in FCCSW. Added generated PCM dictionary as install target (with a check on the detected ROOT version).